### PR TITLE
Use standardized name for palette entry

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "ApplySyntax: Settings",
+        "caption": "Preferences: ApplySyntax",
         "command": "edit_settings", "args": {
             "base_file": "${packages}/ApplySyntax/ApplySyntax.sublime-settings",
             "default": "{\n$0\n}\n"


### PR DESCRIPTION
I keep not finding them because enterinf `prefapply` doesn't yield the expected result.